### PR TITLE
Minimize warranty clause

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -14,12 +14,4 @@ documents and/or other materials provided with the distribution.
 3. The name of the author or authors may not be used to recommend or advertise
 works derived from this software without specific prior written permission.
 
-This software is provided by the author or authors "as is" and any express or
-implied promises, including, but not limited to, the implied promises of fit for
-sale or for a particular purpose are refused. In no event shall the author or
-authors be responsible for any direct, indirect, incidental, special, or other
-damages (including, but not limited to, acquring substitute goods or services;
-loss of use, data, or profits; or business interruption) however caused and on
-any theory of responsibility, whether in contract, strict responsibility, or
-civil (including failure of care or otherwise) arising in any way out of the use
-of this software, even if advised of the possibility of such damage.
+This software is provided by the author or authors with no guarantee.


### PR DESCRIPTION
Warranty clause in English seems very unreliable. I don't think it's a valid option to just rewrite this one in simple words, it just doesn't work. Terms of art matter, there are implied warranties, they sometimes differ by jurisdictions.

You noted that it might not have much relevance anyway. Perhaps you're right, but there's another problem: a single clause poorly written may lead to invalidation of the license.

I'd suggest that a better trade-off is to reuse the simplest existing clause. This exists in Fair license:
http://opensource.org/licenses/Fair

There are issues with this approach too, it just seems to me better than expressing this bunch of legalese in too many work-around words.
